### PR TITLE
Conflicto jquery http

### DIFF
--- a/pg_prestashop_plugin.php
+++ b/pg_prestashop_plugin.php
@@ -21,7 +21,7 @@ class PG_Prestashop_Plugin extends PaymentModule
     {
         $this->name                   = 'pg_prestashop_plugin';
         $this->tab                    = 'payments_gateways';
-        $this->version                = '2.0.1';
+        $this->version                = '2.1.2';
         $this->author                 = FLAVOR.$this->l(' Development');
         $this->currencies             = true;
         $this->currencies_mode        = 'radio';

--- a/views/templates/front/payment.tpl
+++ b/views/templates/front/payment.tpl
@@ -2,7 +2,7 @@
 {block name="content"}
     <link rel="stylesheet" href="{$urls.base_url}/modules/pg_prestashop_plugin/views/css/main.css">
     <script src="https://cdn.paymentez.com/ccapi/sdk/payment_checkout_stable.min.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" type="text/javascript"></script>
+    <script src="https://code.jquery.com/jquery-1.7.1.min.js" type="text/javascript"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/crypto-js.js"></script></head>
 
     <div class="row">


### PR DESCRIPTION
No carga el jquery y  al cliente se le rompe el plugin al abrir checkout. cambio http por https.
Se ha bloqueado la carga del contenido activo mixto "http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"
*Uncaught ReferenceError: jQuery is not defined
    <anonymous> https://vainillascrap.com/module/pg_prestashop_plugin/payment:705
)